### PR TITLE
Add cross-sample consistency for peak/valley positions

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from peak_valley.quality import stain_quality
 from peak_valley import (
     arcsinh_transform, read_counts,
     kde_peaks_valleys, quick_peak_estimate,
-    fig_to_png,
+    fig_to_png, enforce_marker_consistency,
 )
 from peak_valley.gpt_adapter import (
     ask_gpt_peak_count, ask_gpt_prominence, ask_gpt_bandwidth,
@@ -756,6 +756,7 @@ if st.session_state.run_active and st.session_state.pending:
         "ys": ys.tolist(),
     }
     st.session_state.dirty[stem] = False
+    enforce_marker_consistency(st.session_state.results)
 
     _refresh_raw_ridge()
 

--- a/peak_valley/__init__.py
+++ b/peak_valley/__init__.py
@@ -4,3 +4,4 @@ from .data_io       import arcsinh_transform, read_counts
 from .kde_detector   import kde_peaks_valleys, quick_peak_estimate
 from .plotting       import fig_to_png, thumb64
 from .gpt_adapter    import ask_gpt_peak_count           # noqa: F401
+from .consistency    import enforce_marker_consistency    # noqa: F401

--- a/peak_valley/consistency.py
+++ b/peak_valley/consistency.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+import numpy as np
+from typing import Dict, Sequence
+
+__all__ = ["enforce_marker_consistency"]
+
+
+def _local_extreme(xs: np.ndarray, ys: np.ndarray, center: float,
+                   window: float, find_max: bool) -> float:
+    """Return local maximum or minimum near *center* within *window*.
+
+    If the window does not overlap ``xs`` at all the original ``center``
+    value is returned unchanged.
+    """
+    mask = (xs >= center - window) & (xs <= center + window)
+    if not mask.any():
+        return center
+    seg_x = xs[mask]
+    seg_y = ys[mask]
+    idx = np.argmax(seg_y) if find_max else np.argmin(seg_y)
+    return float(seg_x[idx])
+
+
+def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
+                               tol: float = 0.5,
+                               window: float | None = None) -> None:
+    """Detect and correct peak/valley outliers across samples of a marker.
+
+    Parameters
+    ----------
+    results : dict
+        Mapping of sample name to the detector output.  Each value must
+        contain ``peaks``, ``valleys``, ``xs`` and ``ys`` entries.
+    tol : float, optional
+        Deviation from the consensus beyond which a landmark is treated
+        as an outlier.  Expressed in the same units as ``peaks``.
+    window : float | None, optional
+        Search window around the consensus position when fixing outliers.
+        Defaults to ``tol`` if ``None``.
+
+    Notes
+    -----
+    The function updates ``results`` *in place*.
+    """
+    if len(results) < 2:
+        return
+
+    pk_lists = [info["peaks"] for info in results.values() if info.get("peaks")]
+    vl_lists = [info["valleys"] for info in results.values() if info.get("valleys")]
+    if not pk_lists:
+        return
+
+    n_peaks = min(len(p) for p in pk_lists)
+    n_valleys = min(len(v) for v in vl_lists) if vl_lists else 0
+    if n_peaks == 0:
+        return
+
+    pk_cons = [float(np.median([p[i] for p in pk_lists if len(p) > i]))
+               for i in range(n_peaks)]
+    vl_cons = [float(np.median([v[i] for v in vl_lists if len(v) > i]))
+               for i in range(n_valleys)]
+
+    win = tol if window is None else window
+
+    for info in results.values():
+        xs = np.asarray(info.get("xs", []), float)
+        ys = np.asarray(info.get("ys", []), float)
+        pk = list(info.get("peaks", []))
+        vl = list(info.get("valleys", []))
+
+        for i, exp in enumerate(pk_cons):
+            if i < len(pk) and abs(pk[i] - exp) > tol:
+                pk[i] = _local_extreme(xs, ys, exp, win, True)
+
+        for i, exp in enumerate(vl_cons):
+            if i < len(vl) and abs(vl[i] - exp) > tol:
+                vl[i] = _local_extreme(xs, ys, exp, win, False)
+
+        info["peaks"], info["valleys"] = pk, vl

--- a/peak_valley/consistency.py
+++ b/peak_valley/consistency.py
@@ -28,7 +28,8 @@ def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
 
     All samples in ``results`` are compared against marker-wide median
     landmark positions.  Outliers are snapped to local extremes near the
-    consensus position and missing peaks/valleys are added in the same way.
+    consensus position and missing peaks/valleys are added in the same way,
+    **except** for the first peak and first valley which are left untouched.
 
     Parameters
     ----------
@@ -69,18 +70,20 @@ def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
         pk = list(info.get("peaks", []))
         vl = list(info.get("valleys", []))
 
-        for i, exp in enumerate(pk_cons):
-            if i < len(pk):
-                if abs(pk[i] - exp) > tol:
-                    pk[i] = _local_extreme(xs, ys, exp, win, True)
-            else:
-                pk.append(_local_extreme(xs, ys, exp, win, True))
+        if pk:
+            for i, exp in enumerate(pk_cons[1:], start=1):
+                if i < len(pk):
+                    if abs(pk[i] - exp) > tol:
+                        pk[i] = _local_extreme(xs, ys, exp, win, True)
+                else:
+                    pk.append(_local_extreme(xs, ys, exp, win, True))
 
-        for i, exp in enumerate(vl_cons):
-            if i < len(vl):
-                if abs(vl[i] - exp) > tol:
-                    vl[i] = _local_extreme(xs, ys, exp, win, False)
-            else:
-                vl.append(_local_extreme(xs, ys, exp, win, False))
+        if vl:
+            for i, exp in enumerate(vl_cons[1:], start=1):
+                if i < len(vl):
+                    if abs(vl[i] - exp) > tol:
+                        vl[i] = _local_extreme(xs, ys, exp, win, False)
+                else:
+                    vl.append(_local_extreme(xs, ys, exp, win, False))
 
         info["peaks"], info["valleys"] = pk, vl

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from peak_valley.consistency import enforce_marker_consistency
+
+
+def test_enforce_marker_consistency_handles_multiple_landmarks():
+    xs = np.linspace(0.0, 4.0, 401)
+    ys = np.exp(-(xs - 1) ** 2) + np.exp(-(xs - 3) ** 2)
+
+    results = {
+        "s1": {"xs": xs.tolist(), "ys": ys.tolist(),
+                "peaks": [1.0, 3.0], "valleys": [2.0]},
+        "s2": {"xs": xs.tolist(), "ys": ys.tolist(),
+                "peaks": [1.0, 2.0], "valleys": [2.0]},
+        "s3": {"xs": xs.tolist(), "ys": ys.tolist(),
+                "peaks": [1.0], "valleys": []},
+    }
+
+    enforce_marker_consistency(results, tol=0.3, window=1.0)
+
+    assert abs(results["s2"]["peaks"][1] - 3.0) < 0.1
+    assert len(results["s3"]["peaks"]) == 2
+    assert abs(results["s3"]["peaks"][1] - 3.0) < 0.1
+    assert len(results["s3"]["valleys"]) == 1
+    assert abs(results["s3"]["valleys"][0] - 2.0) < 0.1

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -16,15 +16,16 @@ def test_enforce_marker_consistency_handles_multiple_landmarks():
         "s1": {"xs": xs.tolist(), "ys": ys.tolist(),
                 "peaks": [1.0, 3.0], "valleys": [2.0]},
         "s2": {"xs": xs.tolist(), "ys": ys.tolist(),
-                "peaks": [1.0, 2.0], "valleys": [2.0]},
+                "peaks": [1.4, 2.0], "valleys": [2.3]},
         "s3": {"xs": xs.tolist(), "ys": ys.tolist(),
                 "peaks": [1.0], "valleys": []},
     }
 
     enforce_marker_consistency(results, tol=0.3, window=1.0)
 
+    assert abs(results["s2"]["peaks"][0] - 1.4) < 1e-6
+    assert abs(results["s2"]["valleys"][0] - 2.3) < 1e-6
     assert abs(results["s2"]["peaks"][1] - 3.0) < 0.1
     assert len(results["s3"]["peaks"]) == 2
     assert abs(results["s3"]["peaks"][1] - 3.0) < 0.1
-    assert len(results["s3"]["valleys"]) == 1
-    assert abs(results["s3"]["valleys"][0] - 2.0) < 0.1
+    assert results["s3"]["valleys"] == []


### PR DESCRIPTION
## Summary
- add `enforce_marker_consistency` utility to adjust outlier peaks or valleys against marker-wide medians
- export consistency helper and invoke it after each sample is processed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965b25be648326b860e3c5c5a3e26e