### PR TITLE
Group consistency enforcement by marker

### DIFF
--- a/peak_valley/consistency.py
+++ b/peak_valley/consistency.py
@@ -24,9 +24,11 @@ def _local_extreme(xs: np.ndarray, ys: np.ndarray, center: float,
 def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
                                tol: float = 0.5,
                                window: float | None = None) -> None:
-    """Detect and correct peak/valley outliers across samples of a marker.
+    """Detect and correct peak/valley outliers within each marker group.
 
-    All samples in ``results`` are compared against marker-wide median
+    Samples may contain data for multiple protein markers.  The marker name is
+    inferred from the sample key by taking the text after the final underscore.
+    Samples sharing the same marker are compared against marker-wide median
     landmark positions.  Outliers are snapped to local extremes near the
     consensus position and missing peaks/valleys are added in the same way,
     **except** for the first peak and first valley which are left untouched.
@@ -47,43 +49,59 @@ def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
     -----
     The function updates ``results`` *in place*.
     """
+
+    def _enforce_group(group: Dict[str, Dict[str, Sequence[float]]]) -> None:
+        if len(group) < 2:
+            return
+
+        pk_lists = [info["peaks"] for info in group.values()
+                    if info.get("peaks") is not None]
+        vl_lists = [info["valleys"] for info in group.values()
+                    if info.get("valleys") is not None]
+        if not pk_lists:
+            return
+
+        n_peaks = max(len(p) for p in pk_lists)
+        n_valleys = max((len(v) for v in vl_lists), default=0)
+        pk_cons = [float(np.median([p[i] for p in pk_lists if len(p) > i]))
+                   for i in range(n_peaks)]
+        vl_cons = [float(np.median([v[i] for v in vl_lists if len(v) > i]))
+                   for i in range(n_valleys)]
+
+        win = tol if window is None else window
+
+        for info in group.values():
+            xs = np.asarray(info.get("xs", []), float)
+            ys = np.asarray(info.get("ys", []), float)
+            pk = list(info.get("peaks", []))
+            vl = list(info.get("valleys", []))
+
+            if pk:
+                for i, exp in enumerate(pk_cons[1:], start=1):
+                    if i < len(pk):
+                        if abs(pk[i] - exp) > tol:
+                            pk[i] = _local_extreme(xs, ys, exp, win, True)
+                    else:
+                        pk.append(_local_extreme(xs, ys, exp, win, True))
+
+            if vl:
+                for i, exp in enumerate(vl_cons[1:], start=1):
+                    if i < len(vl):
+                        if abs(vl[i] - exp) > tol:
+                            vl[i] = _local_extreme(xs, ys, exp, win, False)
+                    else:
+                        vl.append(_local_extreme(xs, ys, exp, win, False))
+
+            info["peaks"], info["valleys"] = pk, vl
+
     if len(results) < 2:
         return
 
-    pk_lists = [info["peaks"] for info in results.values() if info.get("peaks") is not None]
-    vl_lists = [info["valleys"] for info in results.values() if info.get("valleys") is not None]
-    if not pk_lists:
-        return
+    groups: Dict[str, Dict[str, Dict[str, Sequence[float]]]] = {}
+    for stem, info in results.items():
+        parts = stem.rsplit("_", 1)
+        marker = parts[-1] if len(parts) > 1 else ""
+        groups.setdefault(marker, {})[stem] = info
 
-    n_peaks = max(len(p) for p in pk_lists)
-    n_valleys = max((len(v) for v in vl_lists), default=0)
-    pk_cons = [float(np.median([p[i] for p in pk_lists if len(p) > i]))
-               for i in range(n_peaks)]
-    vl_cons = [float(np.median([v[i] for v in vl_lists if len(v) > i]))
-               for i in range(n_valleys)]
-
-    win = tol if window is None else window
-
-    for info in results.values():
-        xs = np.asarray(info.get("xs", []), float)
-        ys = np.asarray(info.get("ys", []), float)
-        pk = list(info.get("peaks", []))
-        vl = list(info.get("valleys", []))
-
-        if pk:
-            for i, exp in enumerate(pk_cons[1:], start=1):
-                if i < len(pk):
-                    if abs(pk[i] - exp) > tol:
-                        pk[i] = _local_extreme(xs, ys, exp, win, True)
-                else:
-                    pk.append(_local_extreme(xs, ys, exp, win, True))
-
-        if vl:
-            for i, exp in enumerate(vl_cons[1:], start=1):
-                if i < len(vl):
-                    if abs(vl[i] - exp) > tol:
-                        vl[i] = _local_extreme(xs, ys, exp, win, False)
-                else:
-                    vl.append(_local_extreme(xs, ys, exp, win, False))
-
-        info["peaks"], info["valleys"] = pk, vl
+    for group in groups.values():
+        _enforce_group(group)


### PR DESCRIPTION
## Summary
- group samples by marker when enforcing peak/valley consistency
- default to a single group if sample names lack a marker suffix

------
https://chatgpt.com/codex/tasks/task_e_6896d1a1ee948326b897ef7883cde615