### PR TITLE
feat: allow valley drop or slope change for first valley

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ PVdetector is a Streamlit application for detecting density peaks and valleys in
 ### Detection settings
 - **Number of peaks** – enter a fixed value or select “GPT Automatic” with a user-defined maximum.
 - **Bandwidth** and **Prominence** – choose manual presets/scales or allow GPT to suggest values.
-- Additional controls include minimum peak width, curvature threshold, concave turning points, minimum separation, KDE grid size, valley drop, and marker-consistency enforcement.
+- Additional controls include minimum peak width, curvature threshold, concave turning points, minimum separation, KDE grid size, valley drop, first-valley method selection, and marker-consistency enforcement.
 
 ### Running the detector
 - Click **🚀 Run detector** to process selected files. A progress bar tracks the queue, and a Pause/Resume button provides mid-run control.

--- a/app.py
+++ b/app.py
@@ -590,6 +590,11 @@ with st.sidebar:
     min_sep   = st.slider("Min peak separation", 0.0, 10.0, 0.7, 0.1)
     grid_sz  = st.slider("Max KDE grid", 4_000, 40_000, 20_000, 1_000)
     val_drop = st.slider("Valley drop (% of peak)", 1, 50, 10, 1)
+    val_mode = st.radio(
+        "First valley method",
+        ["Slope change", "Valley drop"],
+        horizontal=True,
+    )
 
     st.checkbox(
         "Enforce marker consistency across samples",
@@ -798,7 +803,8 @@ if st.session_state.run_active and st.session_state.pending:
         drop_frac=val_drop / 100.0,
         min_x_sep=min_sep,
         curvature_thresh = curv if curv > 0 else None,
-        turning_peak     = tp
+        turning_peak     = tp,
+        first_valley     = "drop" if val_mode == "Valley drop" else "slope",
     )
 
     if len(peaks) == 1 and not valleys:

--- a/tests/test_first_valley_mode.py
+++ b/tests/test_first_valley_mode.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from peak_valley.kde_detector import kde_peaks_valleys
+
+
+def test_first_valley_slope_mode():
+    rng = np.random.default_rng(0)
+    data = np.concatenate([
+        rng.normal(-1, 0.1, 200),
+        rng.normal(1, 0.1, 200),
+    ])
+    peaks, valleys, *_ = kde_peaks_valleys(
+        data, n_peaks=2, grid_size=2000, first_valley="slope"
+    )
+    assert len(valleys) == 1
+    assert peaks[0] < valleys[0] < peaks[1]
+
+
+def test_first_valley_drop_mode_single_peak():
+    rng = np.random.default_rng(1)
+    data = rng.normal(0, 0.2, 300)
+    peaks, valleys, *_ = kde_peaks_valleys(
+        data, n_peaks=1, grid_size=2000, drop_frac=0.2, first_valley="drop"
+    )
+    assert len(peaks) == 1
+    assert len(valleys) == 1
+    assert valleys[0] > peaks[0]


### PR DESCRIPTION
## Summary
- add optional `first_valley` argument to switch between slope-change and valley-drop algorithms
- expose first valley method selection in UI
- document new first-valley option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a368e615ac8326a2d46f4bcc16ed9f