### PR TITLE
Clamp min_x_sep to valid peak distance in KDE detector

### DIFF
--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -260,7 +260,12 @@ def kde_peaks_valleys(
     grid_dx  = xs[1] - xs[0]
     distance = None                       # (NEW)  hard x-spacing
     if min_x_sep is not None:
-        distance = int(min_x_sep / grid_dx)
+        # ``scipy.signal.find_peaks`` requires ``distance`` >= 1.  For very
+        # small ``min_x_sep`` relative to the grid spacing the integer
+        # division above could yield ``0`` which would raise a ``ValueError``.
+        # Clamp the value so that ``find_peaks`` always receives a valid
+        # minimum distance.
+        distance = max(1, int(min_x_sep / grid_dx))
     kw = {"prominence": prominence}
     if min_width:
         kw["width"] = min_width

--- a/tests/test_min_x_sep.py
+++ b/tests/test_min_x_sep.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from peak_valley.kde_detector import kde_peaks_valleys
+
+
+def test_min_x_sep_smaller_than_grid_spacing():
+    rng = np.random.default_rng(42)
+    data = rng.normal(0, 1, 100)
+    # Use a tiny ``min_x_sep`` to ensure the computed distance would
+    # previously be zero and raise a ValueError in ``find_peaks``.
+    peaks, valleys, xs, ys = kde_peaks_valleys(
+        data, n_peaks=None, min_x_sep=1e-9, grid_size=50
+    )
+    # The call should succeed and return lists for peaks/valleys.
+    assert isinstance(peaks, list)
+    assert isinstance(valleys, list)


### PR DESCRIPTION
## Summary
- prevent ValueError from `find_peaks` when `min_x_sep` is smaller than KDE grid spacing
- add regression test ensuring tiny `min_x_sep` no longer crashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4cdf3f8dc832693f347eb5ea383bf