### PR TITLE
Enhance GPT bandwidth tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PVdetector is a Streamlit application for detecting density peaks and valleys in
 
 ## Features
 - Upload raw counts or full datasets (expression matrix + metadata).
-- Automatic or manual control over KDE bandwidth, peak count, and prominence. GPT-based suggestions are available when an OpenAI API key is provided.
+- Automatic or manual control over KDE bandwidth, peak count, and prominence. GPT-based suggestions (bandwidth scans multiple candidates for optimal peak separation) are available when an OpenAI API key is provided.
 - Interactive per-sample visualization with manual editing of peaks and valleys.
 - Optional enforcement of marker consistency across samples.
 - Landmark alignment and piece-wise linear normalization across samples.


### PR DESCRIPTION
## Summary
- Let GPT choose KDE bandwidth after scanning multiple candidate scale factors and summarizing peak counts
- Document that bandwidth suggestions explore candidates for optimal separation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9a5087483268449f3762cf11f40