### PR TITLE
Add user manual button

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,16 @@ st.warning(
     "**Heads-up:** if you refresh or close this page, all of your uploaded data and results will be lost."
 )
 
+st.markdown(
+    (
+        "<a href='Magic%20Book.html' target='_blank'>"
+        "<button style='position: fixed; top: 10px; right: 10px; z-index: 1000;'>"
+        "User Manual"
+        "</button></a>"
+    ),
+    unsafe_allow_html=True,
+)
+
 st.session_state.setdefault("active_sample", None)
 st.session_state.setdefault("active_subtab", {})   # stem → "plot" / "params" / "manual"
 


### PR DESCRIPTION
## Summary
- Add fixed-position "User Manual" button linking to **Magic Book.html**.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a622314ed48326b86aa4a4ba6ef696