### PR TITLE
Add user manual button

### DIFF
--- a/app.py
+++ b/app.py
@@ -441,6 +441,15 @@ def render_results(container):
 
 # ─────────────────────────────── SIDEBAR ─────────────────────────────────────
 with st.sidebar:
+    st.markdown(
+        (
+            "<a href='Magic%20Book.html' target='_blank'>"
+            "<button style='width:100%; background-color:#ff4b4b; color:white; padding:0.5em; font-size:16px; margin-bottom:10px;'>"
+            "📖 User Manual"
+            "</button></a>"
+        ),
+        unsafe_allow_html=True,
+    )
     mode = st.radio(
         "Choose mode", ["Counts CSV files", "Whole dataset"],
         help="Work with individual counts files or an entire dataset."


### PR DESCRIPTION
## Summary
- Move "User Manual" button into sidebar's top-left to sit with parameter controls.
- Style the button prominently and link to **Magic Book.html**.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a622314ed48326b86aa4a4ba6ef696