### PR TITLE
Add user manual button

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 # app.py  – GPT-assisted bandwidth detector with
 #           live incremental results + per-sample overrides
 from __future__ import annotations
-import io, zipfile, re
+import io, zipfile, re, base64
 from pathlib import Path
 
 import numpy as np
@@ -441,6 +441,11 @@ def render_results(container):
 
 # ─────────────────────────────── SIDEBAR ─────────────────────────────────────
 with st.sidebar:
+    manual_path = Path(__file__).with_name('Magic Book.html')
+    manual_b64 = base64.b64encode(manual_path.read_bytes()).decode()
+    manual_url = f'data:text/html;base64,{manual_b64}'
+    st.link_button('📖 User Manual', manual_url, use_container_width=True)
+
     mode = st.radio(
         "Choose mode", ["Counts CSV files", "Whole dataset"],
         help="Work with individual counts files or an entire dataset."


### PR DESCRIPTION
## Summary
- Move "User Manual" button into sidebar's top-left to sit with parameter controls.
- Style the button prominently and link to **Magic Book.html**.
- Fix button link by embedding manual as base64 and using Streamlit's native button styling for consistency.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a622314ed48326b86aa4a4ba6ef696