### PR TITLE
Improve curvature slider precision and clear generated counts on reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -662,6 +662,7 @@ with st.sidebar:
     )
     curv = st.slider(
         "Curvature thresh (0 = off)", 0.0000, 0.005, 0.0001, 0.0001,
+        format="%.4f",
         help="Filter out peaks with curvature below this value; 0 disables."
     )
     tp   = st.checkbox(
@@ -774,6 +775,8 @@ if clear_col.button("Clear results"):
     for key in ("aligned_counts", "aligned_landmarks",
                 "aligned_ridge_png"):
         st.session_state[key] = None
+
+    st.session_state.generated_csvs.clear()
 
     st.session_state.pending.clear()
     st.session_state.total_todo = 0


### PR DESCRIPTION
## Summary
- Display curvature threshold slider values with four decimal precision to make sub-0.01 increments visible.
- Clear generated counts CSVs when resetting results so old files aren't reprocessed.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b123a9abb88326b67c1f0febad7bba