### PR TITLE
Ensure slope valley does not exceed local minimum

### DIFF
--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -92,6 +92,11 @@ def _first_valley_slope(xs: np.ndarray,
                         p_right: int | None = None) -> float | None:
     """Pick first valley via maximum increase in slope.
 
+    The valley is constrained to lie at or before the local minimum
+    between the first peak and the next peak (if given).  If the point of
+    maximum slope change occurs after the local minimum, the minimum is
+    chosen instead.
+
     Parameters
     ----------
     xs, ys : np.ndarray
@@ -112,17 +117,25 @@ def _first_valley_slope(xs: np.ndarray,
     if p_right is None:
         seg = d2y[p_left:]
         base = p_left
+        y_seg = ys[p_left + 1:]
     else:
         if p_right - p_left <= 2:
             return None
-        seg = d2y[p_left : p_right - 1]
+        seg = d2y[p_left:p_right - 1]
         base = p_left
+        y_seg = ys[p_left + 1:p_right]
     if seg.size == 0:
         return None
     rel = np.argmax(seg)
     if seg[rel] <= 0:
         return None
     idx = base + 1 + rel
+
+    # do not go past the local minimum between the peaks
+    min_idx = p_left + 1 + int(np.argmin(y_seg))
+    if idx > min_idx:
+        idx = min_idx
+
     return float(xs[idx])
 
 

--- a/tests/test_first_valley_mode.py
+++ b/tests/test_first_valley_mode.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from peak_valley.kde_detector import kde_peaks_valleys
+from peak_valley.kde_detector import kde_peaks_valleys, _first_valley_slope
 
 
 def test_first_valley_slope_mode():
@@ -25,3 +25,10 @@ def test_first_valley_drop_mode_single_peak():
     assert len(peaks) == 1
     assert len(valleys) == 1
     assert valleys[0] > peaks[0]
+
+
+def test_slope_valley_not_past_minimum():
+    xs = np.arange(7, dtype=float)
+    ys = np.array([5, 4, 3, 0, 0.1, 4, 5], dtype=float)
+    valley = _first_valley_slope(xs, ys, 0, 6)
+    assert valley == xs[3]


### PR DESCRIPTION
## Summary
- Prevent slope-based first valley from falling after the local minimum by capping at the min
- Add regression test ensuring slope-valley selection stays at or before the local minimum

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74ad220788326b5615feb65da8068