### PR TITLE
Ensure valleys align with peaks

### DIFF
--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -384,6 +384,18 @@ def kde_peaks_valleys(
         if val is not None:
             valleys_x.append(val)
 
+    # --- enforce valley/peak relationship ----------------------------------
+    if len(peaks_x) <= 1:
+        valleys_x = [v for v in valleys_x if (not peaks_x) or v > peaks_x[0]]
+    else:
+        # Keep at most one valley between successive peaks and drop any
+        # valley beyond the last peak
+        expected = []
+        for left, right, val in zip(peaks_x[:-1], peaks_x[1:], valleys_x):
+            if left < val < right:
+                expected.append(val)
+        valleys_x = expected
+
     return np.round(peaks_x, 10).tolist(), valleys_x, xs, ys
 
 # ----------------------------------------------------------------------

--- a/tests/test_valley_constraints.py
+++ b/tests/test_valley_constraints.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from peak_valley.kde_detector import kde_peaks_valleys
+
+
+def test_valleys_between_peaks():
+    rng = np.random.default_rng(42)
+    data = np.concatenate([
+        rng.normal(-2, 0.1, 200),
+        rng.normal(0, 0.1, 200),
+        rng.normal(2, 0.1, 200),
+    ])
+    peaks, valleys, *_ = kde_peaks_valleys(data, n_peaks=3, grid_size=2000)
+    assert len(peaks) == 3
+    assert len(valleys) == 2
+    assert peaks[0] < valleys[0] < peaks[1]
+    assert peaks[1] < valleys[1] < peaks[2]


### PR DESCRIPTION
## Summary
- Enforce that valleys are positioned between successive peaks and never beyond the final peak
- Add regression test validating valleys occur only between peaks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5a35ed483268495816c173ba838