### PR TITLE
Ensure valleys align with peaks

### DIFF
--- a/peak_valley/consistency.py
+++ b/peak_valley/consistency.py
@@ -5,6 +5,20 @@ from typing import Dict, Sequence
 __all__ = ["enforce_marker_consistency"]
 
 
+def _enforce_valley_rule(peaks: Sequence[float],
+                         valleys: Sequence[float]) -> list[float]:
+    """Keep only valleys that lie between successive peaks."""
+    peaks = list(peaks)
+    valleys = list(valleys)
+    if len(peaks) <= 1:
+        return [v for v in valleys if (not peaks) or v > peaks[0]]
+    kept: list[float] = []
+    for left, right, val in zip(peaks[:-1], peaks[1:], valleys):
+        if left < val < right:
+            kept.append(val)
+    return kept
+
+
 def _local_extreme(xs: np.ndarray, ys: np.ndarray, center: float,
                    window: float, find_max: bool) -> float:
     """Return local maximum or minimum near *center* within *window*.
@@ -58,10 +72,15 @@ def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
         if len(group) < 2:
             return
 
-        pk_lists = [info["peaks"] for info in group.values()
-                    if info.get("peaks") is not None]
-        vl_lists = [info["valleys"] for info in group.values()
-                    if info.get("valleys") is not None]
+        pk_lists = []
+        vl_lists = []
+        for info in group.values():
+            pk = list(info.get("peaks", []))
+            vl = _enforce_valley_rule(pk, info.get("valleys", []))
+            info["peaks"], info["valleys"] = pk, vl
+            pk_lists.append(pk)
+            vl_lists.append(vl)
+
         if not pk_lists:
             return
 
@@ -119,6 +138,7 @@ def enforce_marker_consistency(results: Dict[str, Dict[str, Sequence[float]]],
             if vl and vl_cons0 is not None and abs(vl[0] - vl_cons0) > tol:
                 vl[0] = _local_extreme(xs, ys, vl_cons0, win, False)
 
+            vl = _enforce_valley_rule(pk, vl)
             info["peaks"], info["valleys"] = pk, vl
 
     if len(results) < 2:

--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -384,6 +384,18 @@ def kde_peaks_valleys(
         if val is not None:
             valleys_x.append(val)
 
+    # --- enforce valley/peak relationship ----------------------------------
+    if len(peaks_x) <= 1:
+        valleys_x = [v for v in valleys_x if (not peaks_x) or v > peaks_x[0]]
+    else:
+        # Keep at most one valley between successive peaks and drop any
+        # valley beyond the last peak
+        expected = []
+        for left, right, val in zip(peaks_x[:-1], peaks_x[1:], valleys_x):
+            if left < val < right:
+                expected.append(val)
+        valleys_x = expected
+
     return np.round(peaks_x, 10).tolist(), valleys_x, xs, ys
 
 # ----------------------------------------------------------------------

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -31,3 +31,26 @@ def test_enforce_marker_consistency_handles_multiple_landmarks():
     assert len(results["s3"]["peaks"]) == 2
     assert abs(results["s3"]["peaks"][1] - 3.0) < 0.1
     assert results["s3"]["valleys"] == []
+
+
+def test_enforce_marker_consistency_valley_rules():
+    xs = np.linspace(0.0, 4.0, 401)
+    ys = np.exp(-(xs - 1) ** 2) + np.exp(-(xs - 3) ** 2)
+
+    results = {
+        "bad": {"xs": xs.tolist(), "ys": ys.tolist(),
+                 "peaks": [1.0, 3.0], "valleys": [3.5]},
+        "bad2": {"xs": xs.tolist(), "ys": ys.tolist(),
+                  "peaks": [1.0, 3.0], "valleys": [2.0, 3.5]},
+        "good": {"xs": xs.tolist(), "ys": ys.tolist(),
+                  "peaks": [1.0, 3.0], "valleys": [2.0]},
+    }
+
+    enforce_marker_consistency(results, tol=0.3, window=1.0)
+
+    for info in results.values():
+        peaks = info["peaks"]
+        valleys = info["valleys"]
+        assert len(valleys) <= max(0, len(peaks) - 1)
+        for val, left, right in zip(valleys, peaks[:-1], peaks[1:]):
+            assert left < val < right

--- a/tests/test_valley_constraints.py
+++ b/tests/test_valley_constraints.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from peak_valley.kde_detector import kde_peaks_valleys
+
+
+def test_valleys_between_peaks():
+    rng = np.random.default_rng(42)
+    data = np.concatenate([
+        rng.normal(-2, 0.1, 200),
+        rng.normal(0, 0.1, 200),
+        rng.normal(2, 0.1, 200),
+    ])
+    peaks, valleys, *_ = kde_peaks_valleys(data, n_peaks=3, grid_size=2000)
+    assert len(peaks) == 3
+    assert len(valleys) == 2
+    assert peaks[0] < valleys[0] < peaks[1]
+    assert peaks[1] < valleys[1] < peaks[2]


### PR DESCRIPTION
## Summary
- Guard `enforce_marker_consistency` so valleys only exist between successive peaks
- Add regression test confirming consistency enforcement prunes invalid valleys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5a35ed483268495816c173ba838