### PR TITLE
Ensure valleys align with peaks

### DIFF
--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import numpy as np
 from scipy.stats  import gaussian_kde
 from scipy.signal import find_peaks
+from .consistency import _enforce_valley_rule
 
 __all__ = ["kde_peaks_valleys", "quick_peak_estimate"]
 
@@ -383,6 +384,9 @@ def kde_peaks_valleys(
             val = _first_valley_slope(xs, ys, p0)
         if val is not None:
             valleys_x.append(val)
+
+    # --- enforce valley/peak relationship ----------------------------------
+    valleys_x = _enforce_valley_rule(peaks_x, valleys_x)
 
     return np.round(peaks_x, 10).tolist(), valleys_x, xs, ys
 

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -31,3 +31,46 @@ def test_enforce_marker_consistency_handles_multiple_landmarks():
     assert len(results["s3"]["peaks"]) == 2
     assert abs(results["s3"]["peaks"][1] - 3.0) < 0.1
     assert results["s3"]["valleys"] == []
+
+
+def test_enforce_marker_consistency_valley_rules():
+    xs = np.linspace(0.0, 4.0, 401)
+    ys = np.exp(-(xs - 1) ** 2) + np.exp(-(xs - 3) ** 2)
+
+    results = {
+        "bad": {"xs": xs.tolist(), "ys": ys.tolist(),
+                 "peaks": [1.0, 3.0], "valleys": [3.5]},
+        "bad2": {"xs": xs.tolist(), "ys": ys.tolist(),
+                  "peaks": [1.0, 3.0], "valleys": [2.0, 3.5]},
+        "good": {"xs": xs.tolist(), "ys": ys.tolist(),
+                  "peaks": [1.0, 3.0], "valleys": [2.0]},
+    }
+
+    enforce_marker_consistency(results, tol=0.3, window=1.0)
+
+    for info in results.values():
+        peaks = info["peaks"]
+        valleys = info["valleys"]
+        assert len(valleys) <= max(0, len(peaks) - 1)
+        for val, left, right in zip(valleys, peaks[:-1], peaks[1:]):
+            assert left < val < right
+
+
+def test_enforce_marker_consistency_single_peak_drops_extra_valleys():
+    xs = np.linspace(0.0, 2.0, 201)
+    ys = np.exp(-(xs - 1.0) ** 2)
+
+    results = {
+        "bad": {"xs": xs.tolist(), "ys": ys.tolist(),
+                 "peaks": [1.0], "valleys": [1.2, 1.6]},
+        "good": {"xs": xs.tolist(), "ys": ys.tolist(),
+                  "peaks": [1.0], "valleys": [1.3]},
+    }
+
+    enforce_marker_consistency(results, tol=0.3, window=1.0)
+
+    for info in results.values():
+        valleys = info["valleys"]
+        assert len(valleys) <= 1
+        if valleys:
+            assert valleys[0] > info["peaks"][0]

--- a/tests/test_valley_constraints.py
+++ b/tests/test_valley_constraints.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from peak_valley.kde_detector import kde_peaks_valleys
+
+
+def test_valleys_between_peaks():
+    rng = np.random.default_rng(42)
+    data = np.concatenate([
+        rng.normal(-2, 0.1, 200),
+        rng.normal(0, 0.1, 200),
+        rng.normal(2, 0.1, 200),
+    ])
+    peaks, valleys, *_ = kde_peaks_valleys(data, n_peaks=3, grid_size=2000)
+    assert len(peaks) == 3
+    assert len(valleys) == 2
+    assert peaks[0] < valleys[0] < peaks[1]
+    assert peaks[1] < valleys[1] < peaks[2]


### PR DESCRIPTION
## Summary
- Tighten valley rule to keep at most one valley after the first peak and one between each peak pair
- Reuse this rule in the KDE detector so detected valleys never violate peak ordering
- Add regression test ensuring extra valleys after a single peak are pruned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5a35ed483268495816c173ba838