### PR TITLE
Prevent slope-based valley selection beyond first minimum

### DIFF
--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -116,26 +116,27 @@ def _first_valley_slope(xs: np.ndarray,
     """
     d2y = np.diff(ys, n=2)
     if p_right is None:
-        seg = d2y[p_left:]
-        base = p_left
-        y_seg = ys[p_left + 1:]
+        right = len(xs) - 1
     else:
         if p_right - p_left <= 2:
             return None
-        seg = d2y[p_left:p_right - 1]
-        base = p_left
-        y_seg = ys[p_left + 1:p_right]
+        right = p_right
+
+    seg = d2y[p_left:right - 1]
     if seg.size == 0:
         return None
     rel = np.argmax(seg)
     if seg[rel] <= 0:
         return None
-    idx = base + 1 + rel
+    idx = p_left + 1 + rel
 
-    # do not go past the local minimum between the peaks
-    min_idx = p_left + 1 + int(np.argmin(y_seg))
-    if idx > min_idx:
-        idx = min_idx
+    # do not go past the first local minimum between the peaks
+    dy = np.diff(ys[p_left + 1:right + 1])
+    turn = np.where((dy[:-1] < 0) & (dy[1:] >= 0))[0]
+    if turn.size:
+        min_idx = p_left + 2 + turn[0]
+        if idx > min_idx:
+            idx = min_idx
 
     return float(xs[idx])
 

--- a/tests/test_first_valley_mode.py
+++ b/tests/test_first_valley_mode.py
@@ -32,3 +32,10 @@ def test_slope_valley_not_past_minimum():
     ys = np.array([5, 4, 3, 0, 0.1, 4, 5], dtype=float)
     valley = _first_valley_slope(xs, ys, 0, 6)
     assert valley == xs[3]
+
+
+def test_slope_valley_before_deeper_minimum():
+    xs = np.arange(10, dtype=float)
+    ys = np.array([5, 4, 3, 2, 2.2, 5, 0, 5, 6, 7], dtype=float)
+    valley = _first_valley_slope(xs, ys, 0)
+    assert valley == xs[3]


### PR DESCRIPTION
## Summary
- Constrain `_first_valley_slope` so chosen valley never exceeds the first local minimum after the peak
- Add regression test covering deeper-tail scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0bf17df24832698b58a1cc0adc7a3