### PR TITLE
Handle non-finite data in KDE

### DIFF
--- a/peak_valley/kde_detector.py
+++ b/peak_valley/kde_detector.py
@@ -256,6 +256,7 @@ def kde_peaks_valleys(
     first_valley   : str = "slope",
 ):
     x = np.asarray(data, float)
+    x = x[np.isfinite(x)]
     if x.size == 0:
         return [], [], np.array([]), np.array([])
 

--- a/tests/test_nan_handling.py
+++ b/tests/test_nan_handling.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from peak_valley.kde_detector import kde_peaks_valleys
+
+
+def test_kde_peaks_valleys_ignores_nonfinite_values():
+    data = np.array([1.0, 2.0, np.nan, np.inf, 3.0, -np.inf])
+    peaks, valleys, xs, ys = kde_peaks_valleys(data)
+
+    assert np.all(np.isfinite(xs))
+    assert np.all(np.isfinite(ys))
+    assert all(np.isfinite(p) for p in peaks)
+    assert all(np.isfinite(v) for v in valleys)
+
+
+def test_kde_peaks_valleys_all_nonfinite_returns_empty():
+    data = np.array([np.nan, np.inf, -np.inf])
+    peaks, valleys, xs, ys = kde_peaks_valleys(data)
+
+    assert peaks == []
+    assert valleys == []
+    assert xs.size == 0
+    assert ys.size == 0
+


### PR DESCRIPTION
## Summary
- avoid ValueError in KDE by dropping NaN/Inf values before building density
- add regression test for non-finite data handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3339bce708326ac3f05973d6a97ce