### PR TITLE
Add dataset override manager for per-sample parameters

### DIFF
--- a/tests/test_arcsinh_toggle.py
+++ b/tests/test_arcsinh_toggle.py
@@ -14,6 +14,7 @@ from app import _sync_generated_counts
 def setup_state():
     st.session_state.clear()
     st.session_state.generated_csvs = []
+    st.session_state.generated_meta = {}
     st.session_state.results = {}
     st.session_state.results_raw = {}
     st.session_state.params = {}


### PR DESCRIPTION
## Summary
- add a dataset override manager with filtering and bulk editing to tune sample-level parameters before running
- track generated dataset metadata to keep overrides, cached CSVs, and clear operations in sync
- ensure tests account for the new state used by dataset overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8795bf5248326afa5825ad8bcbf5c