### PR TITLE
Tighten multi-peak evidence heuristics

### DIFF
--- a/peak_valley/gpt_adapter.py
+++ b/peak_valley/gpt_adapter.py
@@ -1,14 +1,438 @@
 from __future__ import annotations
-import re, textwrap
-from openai import OpenAI, OpenAIError, AuthenticationError
+
+import json
+import re
+import textwrap
+from typing import Any, Optional
+
 import numpy as np
-from .signature import shape_signature
+from openai import AuthenticationError, OpenAI
+from scipy.signal import find_peaks, peak_prominences, peak_widths
+from sklearn.mixture import GaussianMixture
+
 from .kde_detector import quick_peak_estimate
+from .signature import shape_signature
 
 __all__ = ["ask_gpt_peak_count", "ask_gpt_prominence", "ask_gpt_bandwidth"]
 
 # keep a simple run-time cache; survives a single Streamlit run
 _cache: dict[tuple, float | int | str] = {}  # (tag, sig[, extra]) → value
+
+
+def _prepare_values(counts_full: Optional[np.ndarray]) -> np.ndarray:
+    """Return finite values only (empty array if none)."""
+
+    if counts_full is None:
+        return np.empty(0, dtype=float)
+
+    x = np.asarray(counts_full, dtype=float)
+    if x.size == 0:
+        return np.empty(0, dtype=float)
+
+    mask = np.isfinite(x)
+    if not np.any(mask):
+        return np.empty(0, dtype=float)
+
+    return x[mask]
+
+
+def _robust_limits(x: np.ndarray) -> tuple[float, float]:
+    """Robust (0.5, 99.5) percentile range with fallbacks."""
+
+    if x.size == 0:
+        return 0.0, 1.0
+
+    lo, hi = np.percentile(x, [0.5, 99.5])
+    if not (np.isfinite(lo) and np.isfinite(hi)) or hi <= lo:
+        lo = float(np.min(x))
+        hi = float(np.max(x))
+    if not np.isfinite(lo) or not np.isfinite(hi) or hi <= lo:
+        lo = float(np.min(x)) if x.size else 0.0
+        hi = float(np.max(x)) if x.size else lo + 1.0
+        if not np.isfinite(hi) or hi <= lo:
+            hi = lo + 1.0
+    return float(lo), float(hi)
+
+
+def _smooth_histogram(counts: np.ndarray) -> np.ndarray:
+    """Apply a short [1,4,6,4,1] smoothing kernel."""
+
+    kernel = np.array([1.0, 4.0, 6.0, 4.0, 1.0], dtype=float)
+    kernel /= kernel.sum()
+    return np.convolve(counts.astype(float), kernel, mode="same")
+
+
+def _extract_peak_candidates(
+    centers: np.ndarray,
+    smoothed: np.ndarray,
+) -> tuple[
+    list[dict[str, Any]],
+    Optional[float],
+    Optional[float],
+    Optional[float],
+    Optional[float],
+]:
+    """Return candidate peak descriptors and valley heuristics."""
+
+    if smoothed.size == 0:
+        return [], None, None, None, None
+
+    prom_thresh = np.max(smoothed) * 0.05 if np.max(smoothed) > 0 else 0.0
+    idx, _ = find_peaks(smoothed, prominence=prom_thresh, width=1)
+    if idx.size == 0:
+        return [], None, None, None, None
+
+    prominences, left_bases, right_bases = peak_prominences(smoothed, idx)
+    widths_samples = peak_widths(smoothed, idx, rel_height=0.5)[0]
+
+    # convert widths to the same units as the histogram centres
+    if centers.size > 1:
+        step = float(centers[1] - centers[0])
+    else:
+        step = 1.0
+    widths = widths_samples * step
+
+    peaks: list[dict[str, Any]] = []
+    for order, (i, prom, width, lb, rb) in enumerate(
+        zip(idx, prominences, widths, left_bases, right_bases)
+    ):
+        seg = smoothed[int(lb) : int(rb) + 1]
+        valley_depth = float(seg.min()) if seg.size else None
+        peaks.append(
+            {
+                "x": float(centers[i]),
+                "height": float(smoothed[i]),
+                "prominence": float(prom),
+                "width": float(width),
+                "valley_depth": float(valley_depth) if valley_depth is not None else None,
+                "index": int(i),
+                "order": order,
+            }
+        )
+
+    # heuristics for first valley/right-tail mass/ratios
+    first_valley_x: Optional[float] = None
+    valley_depth_ratio: Optional[float] = None
+    prominence_ratio: Optional[float] = None
+    valley_depth_abs: Optional[float] = None
+    if len(idx) >= 2:
+        left, right = idx[0], idx[1]
+        seg = smoothed[left : right + 1]
+        if seg.size:
+            rel = int(np.argmin(seg))
+            valley_idx = left + rel
+            first_valley_x = float(centers[valley_idx])
+            valley_depth_abs = float(smoothed[valley_idx])
+            denom = min(smoothed[left], smoothed[right])
+            if denom > 0:
+                valley_depth_ratio = float(valley_depth_abs / denom)
+            main_prom = prominences[0]
+            sec_prom = prominences[1]
+            if main_prom > 0:
+                prominence_ratio = float(sec_prom / main_prom)
+
+    return peaks, first_valley_x, valley_depth_ratio, prominence_ratio, valley_depth_abs
+
+
+def _gmm_statistics(x: np.ndarray, max_components: int = 3) -> dict[str, Any]:
+    """Fit Gaussian mixtures (k=1..max_components) and report metrics."""
+
+    stats: dict[str, Any] = {
+        "bic": {},
+        "weights_k2": None,
+        "means_k2": None,
+        "stds_k2": None,
+        "ashmans_d_k2": None,
+        "weights_k3": None,
+        "means_k3": None,
+        "stds_k3": None,
+    }
+
+    if x.size == 0:
+        return stats
+
+    data = x.reshape(-1, 1)
+    gmms: dict[int, GaussianMixture] = {}
+    for k in range(1, max_components + 1):
+        try:
+            gm = GaussianMixture(
+                n_components=k,
+                covariance_type="full",
+                random_state=0,
+                n_init="auto",
+                reg_covar=1e-6,
+            )
+            gm.fit(data)
+            gmms[k] = gm
+            bic_val = gm.bic(data)
+            stats["bic"][f"k{k}"] = float(bic_val) if np.isfinite(bic_val) else None
+        except Exception:
+            stats["bic"][f"k{k}"] = None
+
+    if 2 in gmms:
+        gm2 = gmms[2]
+        means = gm2.means_.ravel()
+        stds = np.sqrt(np.clip(gm2.covariances_.reshape(-1), a_min=0.0, a_max=None))
+        order = np.argsort(means)
+        means = means[order]
+        stds = stds[order]
+        weights = gm2.weights_[order]
+        stats["weights_k2"] = [float(w) for w in weights]
+        stats["means_k2"] = [float(m) for m in means]
+        stats["stds_k2"] = [float(s) for s in stds]
+        denom = float(np.sqrt(stds[0] ** 2 + stds[1] ** 2))
+        if denom > 0:
+            stats["ashmans_d_k2"] = float(np.sqrt(2.0) * abs(means[1] - means[0]) / denom)
+
+    if 3 in gmms:
+        gm3 = gmms[3]
+        means = gm3.means_.ravel()
+        stds = np.sqrt(np.clip(gm3.covariances_.reshape(-1), a_min=0.0, a_max=None))
+        order = np.argsort(means)
+        stats["means_k3"] = [float(m) for m in means[order]]
+        stats["stds_k3"] = [float(s) for s in stds[order]]
+        stats["weights_k3"] = [float(w) for w in gm3.weights_[order]]
+
+    if 1 in stats["bic"] and 2 in stats["bic"]:
+        b1 = stats["bic"].get("k1")
+        b2 = stats["bic"].get("k2")
+        if b1 is not None and b2 is not None:
+            stats["delta_bic_21"] = float(b2 - b1)
+    if 2 in stats["bic"] and 3 in stats["bic"]:
+        b2 = stats["bic"].get("k2")
+        b3 = stats["bic"].get("k3")
+        if b2 is not None and b3 is not None:
+            stats["delta_bic_32"] = float(b3 - b2)
+
+    return stats
+
+
+def _right_tail_mass(x: np.ndarray, cutoff: Optional[float]) -> Optional[float]:
+    if cutoff is None or x.size == 0:
+        return None
+    denom = float(np.sum(np.isfinite(x)))
+    if denom <= 0:
+        return None
+    return float(np.sum(x > cutoff) / denom)
+
+
+def _strong_two_peak_signal(
+    features: dict[str, Any]
+) -> tuple[bool, list[str], Optional[float], dict[str, Any], bool]:
+    """Return (has_signal, reasons, min_weight, separation_info, geom_support)."""
+
+    candidates = features.get("candidates") or {}
+    peaks = candidates.get("peaks") or []
+    valley_ratio = candidates.get("valley_depth_ratio")
+    prominence_ratio = candidates.get("prominence_ratio")
+    right_tail = candidates.get("right_tail_mass_after_first_valley")
+
+    stats = features.get("statistics") or {}
+    gmm = stats.get("gmm") if isinstance(stats, dict) else {}
+    weights_k2 = gmm.get("weights_k2") if isinstance(gmm, dict) else None
+    min_weight = min(weights_k2) if weights_k2 else None
+    delta_bic = gmm.get("delta_bic_21")
+    ashman = gmm.get("ashmans_d_k2")
+
+    mixture_hits: list[str] = []
+    geom_hits: list[str] = []
+    hits: list[str] = []
+    has_weight_support = min_weight is not None and min_weight >= 0.15
+
+    separation_info: dict[str, Any] = {
+        "separation": None,
+        "separation_ratio": None,
+        "separation_ok": None,
+        "geometry_hits": geom_hits,
+    }
+
+    if len(peaks) >= 2:
+        x0 = float(peaks[0].get("x", 0.0))
+        x1 = float(peaks[1].get("x", 0.0))
+        separation = abs(x1 - x0)
+        w0 = float(peaks[0].get("width") or 0.0)
+        w1 = float(peaks[1].get("width") or 0.0)
+        width_scale = max(w0, w1, 1e-9)
+        separation_ratio = separation / width_scale if width_scale > 0 else None
+        if separation_ratio is None:
+            separation_ok = None
+        else:
+            separation_ok = bool(separation_ratio >= 1.8)
+        separation_info.update(
+            {
+                "separation": separation,
+                "separation_ratio": separation_ratio,
+                "separation_ok": separation_ok,
+            }
+        )
+    else:
+        separation_ok = None
+
+    if delta_bic is not None and delta_bic <= -20.0 and has_weight_support:
+        mixture_hits.append("delta_bic")
+
+    if ashman is not None and ashman >= 2.5 and has_weight_support:
+        mixture_hits.append("ashman_d")
+
+    if len(peaks) >= 2 and separation_ok:
+        if valley_ratio is not None and valley_ratio <= 0.65:
+            geom_hits.append("valley_depth_ratio")
+        if right_tail is not None and right_tail >= 0.18:
+            geom_hits.append("right_tail")
+        if prominence_ratio is not None and prominence_ratio >= 0.35:
+            geom_hits.append("prominence_ratio")
+
+    hits.extend(mixture_hits)
+    hits.extend(geom_hits)
+
+    if separation_ok is False:
+        hits = ["insufficient_separation"]
+        separation_info["geometry_hits"] = []
+        return False, hits, min_weight, separation_info, False
+
+    mixture_score = len(mixture_hits)
+    geom_support = len(geom_hits) >= 2
+
+    if mixture_score >= 2:
+        has_signal = True
+    elif mixture_score >= 1 and geom_support:
+        has_signal = True
+    else:
+        has_signal = False
+
+    separation_info["geometry_hits"] = list(geom_hits)
+    return has_signal, hits, min_weight, separation_info, geom_support
+
+
+def _strong_three_peak_signal(features: dict[str, Any]) -> tuple[bool, list[str]]:
+    stats = features.get("statistics") or {}
+    gmm = stats.get("gmm") if isinstance(stats, dict) else {}
+    delta_bic = gmm.get("delta_bic_32")
+    weights_k3 = gmm.get("weights_k3")
+
+    hits: list[str] = []
+
+    if delta_bic is not None and delta_bic <= -10.0:
+        if weights_k3 and min(weights_k3) >= 0.07:
+            hits.append("delta_bic")
+
+    return bool(hits), hits
+
+
+def _apply_peak_caps(
+    feature_payload: dict[str, Any],
+    marker_name: Optional[str],
+    requested_max: int,
+) -> tuple[int, dict[str, Any]]:
+    safe_max = max(1, int(requested_max))
+    heuristics: dict[str, Any] = {}
+
+    heuristics["requested_max"] = safe_max
+
+    tri_modal_markers = {"CD4", "CD45RA", "CD45RO"}
+    tri_modal = bool(marker_name and marker_name.upper() in tri_modal_markers)
+    heuristics["tri_modal_marker"] = tri_modal
+
+    has_two, two_hits, min_weight, separation_info, geom_support = _strong_two_peak_signal(feature_payload)
+    heuristics["evidence_for_two"] = has_two
+    heuristics["support_two_signals"] = two_hits
+    heuristics["min_component_weight_k2"] = min_weight
+    heuristics["peak_separation"] = separation_info
+    heuristics["geometry_support_two"] = geom_support
+
+    if safe_max >= 3 and not tri_modal:
+        safe_max = 2
+        heuristics["non_tri_modal_cap"] = 2
+
+    if safe_max >= 2 and not has_two:
+        safe_max = 1
+        heuristics["forced_peak_cap"] = 1
+
+    if safe_max >= 3:
+        has_three, three_hits = _strong_three_peak_signal(feature_payload)
+        heuristics["evidence_for_three"] = has_three
+        heuristics["support_three_signals"] = three_hits
+        if not has_three:
+            safe_max = 2
+            heuristics["forced_peak_cap"] = heuristics.get("forced_peak_cap", 2)
+    else:
+        heuristics["evidence_for_three"] = False
+        heuristics["support_three_signals"] = []
+
+    heuristics["final_allowed_max"] = safe_max
+    return safe_max, heuristics
+
+
+def _default_priors(marker_name: Optional[str]) -> dict[str, Any]:
+    tri_modal = {"CD4", "CD45RA", "CD45RO"}
+    priors = {
+        "typical_peaks": {
+            "CD4": [1, 3],
+            "CD45RA": [1, 3],
+            "CD45RO": [1, 3],
+        },
+        "others_max": 2,
+    }
+    if marker_name and marker_name.upper() not in tri_modal:
+        priors["marker_max"] = 2
+    return priors
+
+
+def _build_feature_payload(
+    counts_full: Optional[np.ndarray],
+) -> dict[str, Any]:
+    """Construct histogram + analytic features for GPT."""
+
+    payload: dict[str, Any] = {}
+    values = _prepare_values(counts_full)
+    if values.size == 0:
+        return payload
+
+    lo, hi = _robust_limits(values)
+    if hi <= lo:
+        hi = lo + 1.0
+
+    bins = 64
+    clipped = np.clip(values, lo, hi)
+    counts, edges = np.histogram(clipped, bins=bins, range=(lo, hi))
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    smoothed = _smooth_histogram(counts)
+
+    peaks, valley_x, valley_depth_ratio, prominence_ratio, valley_depth_abs = _extract_peak_candidates(
+        centers, smoothed
+    )
+    peaks_out = []
+    for p in peaks[:3]:
+        entry = {
+            "x": p["x"],
+            "height": float(p["height"]),
+            "prominence": float(p["prominence"]),
+            "width": float(p["width"]),
+            "valley_depth": (float(p["valley_depth"]) if p["valley_depth"] is not None else None),
+        }
+        peaks_out.append(entry)
+
+    payload["histogram"] = {
+        "bin_edges": [float(e) for e in edges.tolist()],
+        "counts": [int(c) for c in counts.tolist()],
+    }
+
+    payload["candidates"] = {
+        "peaks": peaks_out,
+        "right_tail_mass_after_first_valley": _right_tail_mass(values, valley_x),
+        "valley_depth_ratio": valley_depth_ratio,
+        "valley_depth_abs": valley_depth_abs,
+        "prominence_ratio": prominence_ratio,
+    }
+
+    gmm_stats = _gmm_statistics(values)
+    payload["statistics"] = {
+        "dip_test_p": None,
+        "silverman_k1_vs_k2_p": None,
+        "gmm": gmm_stats,
+    }
+
+    return payload
 
 def ask_gpt_bandwidth(
     client: OpenAI,
@@ -126,32 +550,114 @@ def ask_gpt_prominence(
     return val
 
 def ask_gpt_peak_count(
-    client:     OpenAI,
+    client: OpenAI,
     model_name: str,
-    max_peaks:  int,
+    max_peaks: int,
     counts_full: np.ndarray | None = None,
     marker_name: str | None = None,
+    *,
+    technology: str | None = None,
+    transform: str | None = None,
+    batch_id: str | None = None,
+    features: Optional[dict[str, Any]] = None,
+    priors: Optional[dict[str, Any]] = None,
 ) -> int | None:
-    """Query GPT for the number of visible density peaks."""
+    """Query GPT for the number of visible density peaks using structured output."""
 
     if client is None:
         return max_peaks
 
-    marker_txt = f"for the protein marker **{marker_name}** " if marker_name else ""
-    prompt = (
-        f"How many density peaks (modes) should be visible in the following raw protein-count list? Remember this is  {marker_txt} (Give a integer ≤ {max_peaks}.)\n\n"
-        f"{counts_full}"
+    requested_max = max(1, int(max_peaks))
+    values = _prepare_values(counts_full)
+
+    payload: dict[str, Any] = {
+        "meta": {
+            "marker": marker_name or "unknown",
+            "technology": technology or "unknown",
+            "transform": transform or "arcsinh(cofactor=5)",
+            "allowed_peaks_max": requested_max,
+        }
+    }
+
+    if batch_id:
+        payload["meta"]["batch_id"] = batch_id
+
+    if values.size:
+        q = np.percentile(values, [5, 25, 50, 75, 95])
+        payload["meta"]["summary"] = {
+            "n": int(values.size),
+            "p5": float(q[0]),
+            "p25": float(q[1]),
+            "median": float(q[2]),
+            "p75": float(q[3]),
+            "p95": float(q[4]),
+        }
+
+    if features is not None:
+        feature_payload = dict(features)
+    else:
+        feature_payload = _build_feature_payload(counts_full)
+
+    safe_max, heuristic_info = _apply_peak_caps(feature_payload, marker_name, requested_max)
+    payload["meta"]["allowed_peaks_max"] = safe_max
+
+    payload.update(feature_payload)
+
+    payload["priors"] = (priors.copy() if isinstance(priors, dict) else _default_priors(marker_name))
+    payload["heuristics"] = heuristic_info
+
+    system = (
+        "You are a cytometry/ADT gating assistant. Infer the number of visible density peaks "
+        "(modes) using only the provided features. Prefer fewer peaks unless strong evidence "
+        "suggests more. For CD4 and sometimes CD45RA/RO, allow 3 peaks; otherwise treat 1–2 as typical. "
+        "Tiny shoulders are not peaks unless prominence and width thresholds are met. Output only the JSON "
+        "object described by the schema."
     )
+
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "peak_decision",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "peak_count": {"type": "integer", "minimum": 1, "maximum": safe_max},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "reason": {"type": "string", "maxLength": 240},
+                    "peak_indices": {"type": "array", "items": {"type": "integer"}},
+                },
+                "required": ["peak_count", "confidence", "reason", "peak_indices"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
     try:
         rsp = client.chat.completions.create(
             model=model_name,
+            temperature=0,
             seed=2025,
-            messages=[{"role": "user", "content": prompt}],
+            timeout=45,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": json.dumps(payload)},
+            ],
+            response_format=response_format,
         )
-        n = int(re.findall(r"\d+", rsp.choices[0].message.content)[0])
-        return min(max_peaks, n) if n > 0 else None
+        msg = rsp.choices[0].message
+        content = msg.content
+        if isinstance(content, list):
+            text = "".join(part.get("text", "") for part in content if isinstance(part, dict))
+        else:
+            text = content or ""
+        data = json.loads(text)
+        peak_count = int(data["peak_count"])
+        if peak_count <= 0:
+            return None
+        return min(safe_max, peak_count)
     except AuthenticationError:
         raise
-    except (OpenAIError, ValueError, IndexError):
-        print("GPT peak count query failed")
-        return max_peaks
+    except Exception as exc:
+        print(f"GPT peak count query failed: {exc}")
+        return safe_max


### PR DESCRIPTION
## Summary
- raise the mixture-weight, separation, and evidence thresholds used to accept GPT multi-peak suggestions so tightly clustered peaks revert to a single-mode cap
- require geometric confirmation alongside mixture statistics and expose the supporting geometry hits and flag in the heuristic payload for downstream inspection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d1cda77883269a2968678ddfd0e5