### PR TITLE
Refine landmark alignment to mirror ADTnorm behaviour

### DIFF
--- a/peak_valley/alignment.py
+++ b/peak_valley/alignment.py
@@ -49,6 +49,9 @@ def fill_landmark_matrix(
     max_pk = max(pk_lengths, default=0)
     max_vl = max(vl_lengths, default=0)
 
+    has_val_orig = max_vl > 0
+    has_pos_orig = any(length > 1 for length in pk_lengths)
+
     pk_mat = np.full((n, max_pk if max_pk > 0 else 1), np.nan)
     vl_mat = np.full((n, max_vl if max_vl > 0 else 1), np.nan)
 
@@ -102,7 +105,7 @@ def fill_landmark_matrix(
         # --- return early for 1- or 2-anchor regimes --------------------
         if align_type == "negPeak":
             return out[:, :1]
-        if align_type == "negPeak_valley":
+        if align_type == "negPeak_valley" or (has_val_orig and not has_pos_orig):
             return out
 
         # ---- need a surrogate positive peak ----------------------------

--- a/peak_valley/alignment.py
+++ b/peak_valley/alignment.py
@@ -79,8 +79,8 @@ def fill_landmark_matrix(
     # the “last” peak has to be extracted explicitly or it disappears
     pos = np.full(n, np.nan)
     for i, pk in enumerate(peaks):
-        if pk:                           # non‑empty list
-            pos[i] = pk[-1]              # last element, no matter how many
+        if pk and len(pk) > 1:           # needs a distinct positive peak
+            pos[i] = pk[-1]              # last element, true positive peak
     neg_thr = neg_thr if neg_thr is not None else np.arcsinh(10 / 5 + 1)
 
     if align_type == "valley":
@@ -124,8 +124,13 @@ def fill_landmark_matrix(
             diff_med = np.nanmedian(out[:, 1])
         if np.isnan(diff_med) or diff_med <= 0:
             diff_med = max(neg_thr, 1.0)
-        pos_fill = out[:, 1] + diff_med
-        out      = np.column_stack([out, pos_fill])
+
+        pos_imputed = np.where(
+            np.isnan(pos),
+            out[:, 1] + diff_med,
+            pos,
+        )
+        out = np.column_stack([out, pos_imputed])
         return out
 
     # ── have ≥2 peaks ──────────────────────────────────────────────────────

--- a/tests/test_alignment_density.py
+++ b/tests/test_alignment_density.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from peak_valley.alignment import align_distributions
+
+
+def test_align_distributions_returns_density_warp():
+    counts = [
+        np.array([0.0, 0.5, 1.0]),
+        np.array([-0.1, 0.0, 0.1, 0.2]),
+    ]
+    peaks = [[0.0, 1.0], [-0.1, 0.2]]
+    valleys = [[0.4], [0.05]]
+
+    xs = np.linspace(-0.2, 1.2, 10)
+    ys = np.linspace(0.0, 1.0, 10)
+    density_grids = [(xs, ys), None]
+
+    warped_counts, warped_landmarks, warp_funs, warped_density = align_distributions(
+        counts,
+        peaks,
+        valleys,
+        density_grids=density_grids,
+    )
+
+    assert len(warped_density) == len(counts)
+    xs_warp, ys_warp = warped_density[0]
+    np.testing.assert_allclose(xs_warp, warp_funs[0](xs))
+    np.testing.assert_allclose(ys_warp, ys)
+    assert warped_density[1] is None
+
+
+def test_align_distributions_density_shape_mismatch():
+    counts = [np.array([0.0, 0.5, 1.0])]
+    peaks = [[0.0, 1.0]]
+    valleys = [[0.4]]
+
+    with pytest.raises(ValueError):
+        align_distributions(
+            counts,
+            peaks,
+            valleys,
+            density_grids=[(np.array([0, 1]), np.array([0, 1, 2]))],
+        )
+

--- a/tests/test_fill_landmark_matrix.py
+++ b/tests/test_fill_landmark_matrix.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from peak_valley.alignment import fill_landmark_matrix
+
+
+def test_fill_landmark_matrix_preserves_observed_positive_peaks():
+    peaks = [
+        [0.1, 1.2],   # has explicit positive peak
+        [0.05],       # only negative peak detected
+        [0.2, 0.9],   # also has a positive peak
+    ]
+    valleys = [
+        [0.45],
+        [0.32],
+        [0.4],
+    ]
+
+    mat = fill_landmark_matrix(peaks, valleys)
+
+    assert mat.shape == (3, 3)
+
+    # Samples with real positive peaks keep their original location
+    assert mat[0, 2] == pytest.approx(1.2)
+    assert mat[2, 2] == pytest.approx(0.9)
+
+    # Samples missing a positive peak receive an imputed landmark
+    assert mat[1, 2] > mat[1, 1]
+
+
+def test_fill_landmark_matrix_respects_alignment_mode():
+    peaks = [[0.1], [0.2]]
+    valleys = [[0.4], [0.45]]
+
+    mat_neg_only = fill_landmark_matrix(peaks, valleys, align_type="negPeak")
+    assert mat_neg_only.shape == (2, 1)
+    assert np.allclose(mat_neg_only[:, 0], [0.1, 0.2])
+
+    mat_neg_val = fill_landmark_matrix(
+        peaks,
+        valleys,
+        align_type="negPeak_valley",
+    )
+    assert mat_neg_val.shape == (2, 2)
+    assert np.allclose(mat_neg_val[:, 0], [0.1, 0.2])
+    assert np.allclose(mat_neg_val[:, 1], [0.4, 0.45])


### PR DESCRIPTION
## Summary
- rebuild the ragged peak/valley handling to more faithfully reproduce ADTnorm's NA-filling rules
- guard target landmark inputs and keep warp identity functions for samples without usable anchors
- ensure alignment targets use column-wise nan means so missing peaks do not poison cohort averages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce25f980a48326b2700653b5451bd7