### PR TITLE
Adjust dataset export formats and add combined download

### DIFF
--- a/tests/test_arcsinh_toggle.py
+++ b/tests/test_arcsinh_toggle.py
@@ -29,7 +29,8 @@ def setup_state():
 
 def read_bio(bio: io.BytesIO) -> np.ndarray:
     bio.seek(0)
-    return np.loadtxt(bio)
+    df = pd.read_csv(bio)
+    return df.iloc[:, 0].to_numpy()
 
 
 def test_arcsinh_applied():


### PR DESCRIPTION
## Summary
- include the marker header when exporting individual sample CSVs
- drop the processed data file from dataset downloads and ensure aligned exports only contain aligned values
- add a download option that bundles both before- and after-alignment dataset CSVs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dadba7d8f08326a1bde558424bd825