### PR TITLE
Fix individual CSV exports and parsing

### DIFF
--- a/peak_valley/data_io.py
+++ b/peak_valley/data_io.py
@@ -23,40 +23,72 @@ def read_counts(
     file: io.BytesIO | str | Path,
     header_row: int,
     skip_rows: int,
-) -> np.ndarray:
+) -> tuple[np.ndarray, dict[str, str | None]]:
     """
-    Read a *_raw_counts.csv* that contains **one numeric column**.
-    Handles giant files by streaming.
+    Read a *_raw_counts.csv* that contains one column of counts.
+
+    The function tolerates a free-form text entry (for example the marker name)
+    in the first data row and returns it via the accompanying metadata dict.
     """
+
+    def _extract_values(series: pd.Series,
+                        protein: str | None) -> tuple[np.ndarray, str | None]:
+        """Return numeric values and update ``protein`` when present."""
+
+        raw_values = series.astype("object")
+        numeric = pd.to_numeric(raw_values, errors="coerce")
+
+        if protein is None:
+            mask = numeric.isna()
+            if mask.any():
+                first = raw_values[mask].dropna()
+                for value in first:
+                    text = str(value).strip()
+                    if text and text.lower() not in {"nan", "none"}:
+                        protein = text
+                        break
+
+        valid = numeric.dropna().astype("float64")
+        return valid.values, protein
+
     # accept path-like too (handy for future CLI use)
     if not hasattr(file, "read"):
         file = open(file, "rb")
 
     file.seek(0)
     hdr = None if header_row < 0 else header_row
-    try:                                             # fast path
-        return (
-            pd.read_csv(
-                file,
-                header=hdr,
-                skiprows=skip_rows or None,
-                usecols=[0],
-                dtype="float64",
-                engine="c",
-                memory_map=True,
-            )
-            .squeeze("columns")
-            .values
-        )
-    except ValueError:                              # stream when huge
+    common_kwargs = dict(
+        header=hdr,
+        skiprows=skip_rows or None,
+        usecols=[0],
+        engine="c",
+    )
+
+    protein_name: str | None = None
+
+    try:  # fast path
+        series = pd.read_csv(
+            file,
+            dtype="object",
+            memory_map=True,
+            **common_kwargs,
+        ).squeeze("columns")
+        values, protein_name = _extract_values(series, protein_name)
+    except ValueError:  # stream when huge
         file.seek(0)
         chunks = pd.read_csv(
             file,
-            header=hdr,
-            skiprows=skip_rows or None,
-            usecols=[0],
-            dtype="float64",
-            engine="c",
+            dtype="object",
             chunksize=200_000,
+            **common_kwargs,
         )
-        return np.concatenate([c.values.ravel() for c in chunks])
+        arrays: list[np.ndarray] = []
+        for frame in chunks:
+            col = frame.squeeze("columns")
+            vals, protein_name = _extract_values(col, protein_name)
+            if vals.size:
+                arrays.append(vals)
+        values = np.concatenate(arrays) if arrays else np.empty(0)
+
+    metadata = {"protein_name": protein_name}
+    return values, metadata

--- a/tests/test_read_counts.py
+++ b/tests/test_read_counts.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import io
+
+import numpy as np
+
+from peak_valley.data_io import read_counts
+
+
+def _make_csv(contents: str) -> io.BytesIO:
+    bio = io.BytesIO(contents.encode("utf-8"))
+    bio.seek(0)
+    return bio
+
+
+def test_read_counts_extracts_protein_name_without_header() -> None:
+    csv = "\n".join(["CD3", "1", "2", "3"]) + "\n"
+    counts, meta = read_counts(_make_csv(csv), header_row=-1, skip_rows=0)
+
+    assert meta["protein_name"] == "CD3"
+    np.testing.assert_array_equal(counts, np.array([1.0, 2.0, 3.0]))
+
+
+def test_read_counts_respects_header_row() -> None:
+    csv = "\n".join(["Counts", "CD4", "5", "6"]) + "\n"
+    counts, meta = read_counts(_make_csv(csv), header_row=0, skip_rows=0)
+
+    assert meta["protein_name"] == "CD4"
+    np.testing.assert_array_equal(counts, np.array([5.0, 6.0]))


### PR DESCRIPTION
## Summary
- allow `read_counts` to capture marker labels while parsing single-column CSVs
- cache per-sample metadata and add the raw/aligned CSV exports to the before/after alignment downloads
- cover the new parsing behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dae07e9e9c8326ab37308bf879ca1b